### PR TITLE
Port change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ docker:
 docker-run:
 	(docker rm -f meshery-octarine) || true
 	docker run --name meshery-octarine -d \
-	-p 10004:10004 \
+	-p 10003:10003 \
 	-e DEBUG=true \
 	layer5/meshery-octarine
 

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ import (
 )
 
 var (
-	gRPCPort = flag.Int("grpc-port", 10004, "The gRPC server port")
+	gRPCPort = flag.Int("grpc-port", 10003, "The gRPC server port")
 )
 
 var log grpclog.LoggerV2


### PR DESCRIPTION
Changed the port number from 10004 to 10003 as mentioned in https://meshery.layer5.io/docs/architecture#network-ports-that-meshery-uses-and-needs

Signed-off-by: Harshini-M hm@luminanetworks.com