### PR TITLE
fixes ci.yml to pass build failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,32 +23,32 @@ jobs:
       with:
         go-version: ${{ secrets.GO_VERSION }}
     - run: GOPROXY=direct GOSUMDB=off go get -u golang.org/x/lint/golint; go list ./... | grep -v /vendor/ | xargs -L1 /home/runner/go/bin/golint -set_exit_status
-#   error_check:
-#     name: Error check
-#     runs-on: ubuntu-latest
-#     steps:
-#     - name: Check out code
-#       uses: actions/checkout@master
-#       with:
-#         fetch-depth: 1
-#     - name: Setup Go
-#       uses: actions/setup-go@v1
-#       with:
-#         go-version: ${{ secrets.GO_VERSION }}
-#     - run: GOPROXY=direct GOSUMDB=off GO111MODULE=on go get -u github.com/kisielk/errcheck; /home/runner/go/bin/errcheck ./...
-#   static_check:
-#     name: Static check
-#     runs-on: ubuntu-latest
-#     steps:
-#     - name: Check out code
-#       uses: actions/checkout@master
-#       with:
-#         fetch-depth: 1
-#     - name: Setup Go
-#       uses: actions/setup-go@v1
-#       with:
-#         go-version: ${{ secrets.GO_VERSION }}
-#     - run: GOPROXY=direct GOSUMDB=off GO111MODULE=on go get -u honnef.co/go/tools/cmd/staticcheck; /home/runner/go/bin/staticcheck -checks all ./... # https://staticcheck.io/docs/checks
+  error_check:
+     name: Error check
+     runs-on: ubuntu-latest
+     steps:
+     - name: Check out code
+       uses: actions/checkout@master
+       with:
+         fetch-depth: 1
+     - name: Setup Go
+       uses: actions/setup-go@v1
+       with:
+         go-version: ${{ secrets.GO_VERSION }}
+     - run: GOPROXY=direct GOSUMDB=off GO111MODULE=on go get -u github.com/kisielk/errcheck; /home/runner/go/bin/errcheck ./...
+  static_check:
+     name: Static check
+     runs-on: ubuntu-latest
+     steps:
+     - name: Check out code
+       uses: actions/checkout@master
+       with:
+         fetch-depth: 1
+     - name: Setup Go
+       uses: actions/setup-go@v1
+       with:
+         go-version: ${{ secrets.GO_VERSION }}
+     - run: GOPROXY=direct GOSUMDB=off GO111MODULE=on go get -u honnef.co/go/tools/cmd/staticcheck; /home/runner/go/bin/staticcheck -checks all ./... # https://staticcheck.io/docs/checks
 #   vet:
 #     name: Vet
 #     runs-on: ubuntu-latest


### PR DESCRIPTION
Signed-off-by: ashiscs <ashissingh640@gmail.com>

Due to extra space given at starting of error_check and static_check the yaml file was giving error, this pr addresses the issue !! 